### PR TITLE
Added a simple method for running the examples from the Gradle comman…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,3 +90,8 @@ license {
     strictCheck = true
 }
 
+task execute(type:JavaExec) {
+   main = "ch.petikoch.examples.mvvm_rxjava.example" + exampleNum + ".Example_" + exampleNum + "_Main"
+   classpath = sourceSets.main.runtimeClasspath
+}
+


### PR DESCRIPTION
A way to run the examples from the command-line without needing to go into an IDE. For example, to run example 7a:

`./gradlew -PexampleNum=7a execute`

Perhaps there are other ways (or better ways) of doing so.
